### PR TITLE
Removal of PAT (Personal Access Token) token

### DIFF
--- a/.github/workflows/test-action.yaml
+++ b/.github/workflows/test-action.yaml
@@ -17,8 +17,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install NCTL scan
         uses: ./
       - name: Check install

--- a/.github/workflows/test-action.yaml
+++ b/.github/workflows/test-action.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - "*"
+      - main
 
 jobs:
   default:

--- a/.github/workflows/test-action.yaml
+++ b/.github/workflows/test-action.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - main
+      - "*"
 
 jobs:
   default:

--- a/.github/workflows/test-action.yaml
+++ b/.github/workflows/test-action.yaml
@@ -17,8 +17,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-        with:
-          token: ${{ secrets.PAT }}
       - name: Install NCTL scan
         uses: ./
       - name: Check install

--- a/.github/workflows/test-action.yaml
+++ b/.github/workflows/test-action.yaml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install NCTL scan
         uses: ./
       - name: Check install


### PR DESCRIPTION
I was working on removal of PAT, and while finding the use of PAT across nirmata, I came to this codebase.
I tried to 
1. Remove the PAT token
2. Replace the PAT token with Github Token

Both the flow worked,
but because this workflow worked without token, I am suggesting the change to remove the token.

Please refer to confirm the working flow:
https://github.com/nirmata/action-install-nctl-scan/actions/runs/12451838303