### PR TITLE
fix: pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/bump-nctl-version.yaml
+++ b/.github/workflows/bump-nctl-version.yaml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Create GitHub App token for go-nctl repository
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547  # v1
         id: app-token
         with:
           app-id: ${{ vars.NCTL_VERSION_BUMPER_GITHUB_APP_ID }}

--- a/.github/workflows/test-action.yaml
+++ b/.github/workflows/test-action.yaml
@@ -16,7 +16,7 @@ jobs:
     name: Install NCTL scan
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5  # v2
       - name: Install NCTL scan
         uses: ./
       - name: Check install


### PR DESCRIPTION
## Summary

Pins all GitHub Actions `uses:` references to full commit SHAs to prevent supply chain attacks via tag mutation.

### Changes
- `actions/checkout@v4 -> @34e11487...`
- `actions/create-github-app-token@v1 -> @d72941d7...`
- `actions/checkout@v2 -> @ee0669bd...`


### Why

This repo was flagged as **HIGH** risk: unpinned actions triggered by pull requests allow fork-based supply chain attacks.

Tracked in: https://github.com/nirmata/platform-engineering-policies/issues/33
